### PR TITLE
Fix writeRecode to handle values with greater than 12 characters

### DIFF
--- a/PyHLA.py
+++ b/PyHLA.py
@@ -1652,15 +1652,15 @@ def writeRecode(infile, digits, test, model):
     tmp = tmp + '.txt'
     f = open(tmp,'w')
     ans, header = allelicRecode(infile, digits, test, model)
-    for i in header:
-        i = string.replace(i, '*', '_') # change A*01:01 to A_01_01
-        i = string.replace(i, ':', '_')
-        f.write("%12s" % i,)
+    tab = string.maketrans('*:', '__')
+    header = map(lambda i: i.translate(tab), header)
+    f.write('\t'.join(header))
     f.write('\n')
+    f.flush()
     for i in ans:
-        for j in ans[i]:
-            f.write("%12s" % j,)
+        f.write('\t'.join(map(str, ans[i])))
         f.write('\n')
+        f.flush()
     f.close()
     return tmp
 def regressionLogistic(infile, digits, freq, model = 'additive', adjust = 'FDR', exclude=None, covfile=None, covname=None, perm=None, seed=None, test='logistic'):


### PR DESCRIPTION
`writeRecode` has an issue where each value is limited to 12 characters. If an input value is greater than 12 characters, `writeRecode` ends up joining these fields together and they aren't properly parsed out.

For example, I have an input that looks like this (shortened and sample names modified for this purpose):
```
Sample1    -1.2250236259803726     A*02:01:01G     A*02:01:01G     B*57:01:01G     B*27:05:02G     C
Sample1    -0.8533907976634307     A*11:01:01G     A*02:01:01G     B*08:01:01G     B*08:01:01G     C
Sample2    0.4293614430329766      A*03:01:01G     A*25:01:01G     B*44:02:01G     B*40:01:01G     C
Sample3    0.8533907976634307      A*74:01:01G     A*30:01:01G     B*42:01:01      B*15:03:01G     C
Sample4    -0.7064943341396838     A*01:01:01G     A*02:01:01G     B*07:02:01G     B*38:01:01      C
Sample5    1.2909491476822743      A*01:01:01G     A*24:02:01G     B*15:01:01G     B*40:01:01G
```

Since the values in the genotype column are longer than twelve characters, they get mushed together in the phenotype column. As seen below, the rownames for the matrix that comes from `writeRecode` are tuples, and that is probably not what it should be.
```python
> import PyHLA
> import pandas
> tfile = PyHLA.writeRecode(ifile, dig, test, model)
> rec = pandas.read_csv(tfile, delim_whitespace = True, header = 0)
> list(rec.index)[:5]
[('SampleN10.2936812406469763', 1, 0), ('SampleN20.5001214437103313', 1, 0), ('SampleN31.1140081089467637', 0, 0), ('SampleN4-1.0090185815811057', 0, 0), ('SampleN50.8480264349588851', 0, 0)]
```

As consequence, the p-values are not correct since they're testing the wrong columns. Using the old `writeRecode`, we get p-values such as:
```
              Allele    Freq  P_Linear    beta     L95     U95     P_adj
             A*01:01  0.2567    0.4133 -0.0019 -0.0066  0.0027    0.6220
             A*02:06  0.1306    0.5926 -0.0016 -0.0077  0.0044    0.6220
             A*11:02  0.1075    0.6220 -0.0017 -0.0084  0.0050    0.6220
             A*69:01  0.1164    0.6079 -0.0017 -0.0082  0.0048    0.6220
            B*07:05B  0.0933        NA        NA        NA        NA        NA
             B*13:02  0.0567    0.7247 -0.0016 -0.0107  0.0075    0.7328
```

which also includes NAs and are not reproducible.

With this patched version of `writeRecode`, which simply uses tabs instead of 12 characters to delimit each column in `tfile`, we get p-values that are reproducible in R:
```
              Allele    Freq  P_Linear    beta     L95     U95     P_adj
             A*01:01  0.1410    0.6428  0.0346 -0.1117  0.1808    0.6428
             A*02:01  0.2567    0.0851 -0.1053 -0.2252  0.0146    0.3043
             A*03:01  0.1306    0.2135 -0.0979 -0.2522  0.0565    0.3043
             A*24:02  0.1075    0.2282 -0.1061 -0.2789  0.0667    0.3043
             B*07:02  0.1164    0.3006 -0.0876 -0.2537  0.0784    0.5027
             B*08:01  0.0933    0.9917 -0.0009 -0.1792  0.1773    0.9917
```

Again, my patch delimits the recoded table with tabs instead of 12 characters. My coding style is different (functional, so use of maps instead of for loops), but it allows for reproducible results.